### PR TITLE
Add EXPOSE for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:11.0.1-jdk-slim-sid
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
+EXPOSE 9001
 ENTRYPOINT ["java","-jar","/app.jar"]
 
 ARG BUILD_DATE


### PR DESCRIPTION
Just a simple addition to Dockerfile with expose of port 9001.
Allows some proxy software (e.g. Traefik) to catch container port without need to configure it.